### PR TITLE
Add open-banking.io to API Aggregators

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ If you see a package or project here that is no longer maintained or is not a go
 
 * [Plaid](https://plaid.com/docs/)
 * [Token](https://developer.token.io/)
+* [open-banking.io](https://open-banking.io/) - open-banking.io is a zero-knowledge EU PSD2 open banking API aggregator providing read-only AISP access to bank accounts and transactions. No eIDAS/qWAC certificate required.
 * [Yapily](https://docs.yapily.com/)
 * [Tink](https://docs.tink.com/)
 * [Brankas](https://brank.as/docs)


### PR DESCRIPTION
Added open-banking.io to the API Aggregators section.

open-banking.io is a zero-knowledge EU PSD2 open banking API aggregator providing read-only AISP access to bank accounts and transactions. Unlike other aggregators in the list, it requires no eIDAS/qWAC certificate, lowering the barrier for hobbyists and small fintechs in the EU.

The entry follows the existing list format and is placed alongside Plaid, Token, Tink, Yapily, TrueLayer, etc.